### PR TITLE
Feature: amqp-spy

### DIFF
--- a/amqp-utils.gemspec
+++ b/amqp-utils.gemspec
@@ -20,32 +20,31 @@ Gem::Specification.new do |s|
     "README.txt"
   ]
   s.files = [
-    ".gitignore",
-     "History.txt",
-     "License.txt",
-     "README.txt",
-     "Rakefile",
-     "TODO.txt",
-     "VERSION",
-     "amqp-utils.gemspec",
-     "bin/amqp-deleteq",
-     "bin/amqp-dequeue",
-     "bin/amqp-enqueue",
-     "bin/amqp-peek",
-     "bin/amqp-pop",
-     "bin/amqp-purge",
-     "bin/amqp-statq",
-     "lib/amqp_utils.rb",
-     "lib/amqp_utils/command.rb",
-     "lib/amqp_utils/message_formatter.rb",
-     "test/test_amqp_utils.rb",
-     "test/test_helper.rb"
+    "History.txt",
+    "License.txt",
+    "README.txt",
+    "Rakefile",
+    "TODO.txt",
+    "VERSION",
+    "amqp-utils.gemspec",
+    "bin/amqp-deleteq",
+    "bin/amqp-dequeue",
+    "bin/amqp-enqueue",
+    "bin/amqp-peek",
+    "bin/amqp-pop",
+    "bin/amqp-purge",
+    "bin/amqp-spy",
+    "bin/amqp-statq",
+    "lib/amqp_utils.rb",
+    "lib/amqp_utils/command.rb",
+    "lib/amqp_utils/message_formatter.rb",
+    "test/test_amqp_utils.rb",
+    "test/test_helper.rb"
   ]
   s.homepage = %q{http://github.com/dougbarth/amqp-utils}
-  s.rdoc_options = ["--charset=UTF-8"]
   s.require_paths = ["lib"]
   s.rubyforge_project = %q{amqp-utils}
-  s.rubygems_version = %q{1.3.6}
+  s.rubygems_version = %q{1.3.7}
   s.summary = %q{Command line utilities for interacting with AMQP compliant queues}
   s.test_files = [
     "test/test_amqp_utils.rb",

--- a/bin/amqp-spy
+++ b/bin/amqp-spy
@@ -1,0 +1,54 @@
+#!/usr/bin/env ruby
+
+require File.dirname(__FILE__) + '/../lib/amqp_utils/command'
+require File.dirname(__FILE__) + '/../lib/amqp_utils/message_formatter'
+
+class SpyCommand < AmqpUtils::Command
+  def prepare_options(options)
+    options.banner %Q{
+    |Spies on a specific exchange and routing key.
+    |
+    |   #{command_name} <exchange> [<routing_key>]
+    |
+    |Spy options:
+    }.margin
+    options.opt :fanout, "Fanout exchange", :short => "F"
+    options.opt :direct, "Direct exchange", :short => "D"
+    options.opt :topic, "Topic exchange", :short => 'T'
+    options.opt :durable, 'Is the exchange durable?', :short => 'd'
+    options.opt :auto_delete, 'Is it an auto-deleted exchange?', :short => 'a'
+    options.opt :format, 'The format that the messages should be displayed as',
+      :short => :none, :default => 'pretty'
+  end
+
+  def validate
+    Trollop::die "needs an exchange name" unless args[0] && !args[0].empty?
+    if !options[:fanout] && !options[:direct] && !options[:topic]
+      Trollop::die "one of the fanout, direct, or topic options are required"
+    end
+
+    @formatter = AmqpUtils::MessageFormatter.for_type(options[:format])
+    Trollop::die :format, "not an available type: #{AmqpUtils::MessageFormatter.types.join(", ")}" unless @formatter
+  end
+
+  def execute
+    options[:type] = (options[:fanout]) ? :fanout : ((options[:direct]) ? :direct : :topic)
+    @exchange_name = args[0]
+    @routing_key = (options[:type] != :fanout) ? (args[1] || '*') : nil
+    spy_queue = "amqp-spy.#{@routing_key}." + (0...6).map{ (('a'..'f').to_a + (0..9).to_a)[rand(16)] }.join
+    
+    mq = MQ.new
+    
+    exchange = MQ::Exchange.new(mq, options[:type], @exchange_name, :durable => options[:durable],
+      :auto_delete => options[:auto_delete])
+    
+    queue = MQ::Queue.new(mq, spy_queue, :auto_delete => true)
+    queue.bind(exchange, :routing_key => @routing_key)
+    
+    queue.subscribe do |header, message|
+      @formatter.generate(STDOUT, header, message)
+    end
+  end
+end
+
+SpyCommand.run

--- a/bin/amqp-spy
+++ b/bin/amqp-spy
@@ -12,20 +12,12 @@ class SpyCommand < AmqpUtils::Command
     |
     |Spy options:
     }.margin
-    options.opt :fanout, "Fanout exchange", :short => "F"
-    options.opt :direct, "Direct exchange", :short => "D"
-    options.opt :topic, "Topic exchange", :short => 'T'
-    options.opt :durable, 'Is the exchange durable?', :short => 'd'
-    options.opt :auto_delete, 'Is it an auto-deleted exchange?', :short => 'a'
     options.opt :format, 'The format that the messages should be displayed as',
       :short => :none, :default => 'pretty'
   end
 
   def validate
     Trollop::die "needs an exchange name" unless args[0] && !args[0].empty?
-    if !options[:fanout] && !options[:direct] && !options[:topic]
-      Trollop::die "one of the fanout, direct, or topic options are required"
-    end
 
     @formatter = AmqpUtils::MessageFormatter.for_type(options[:format])
     Trollop::die :format, "not an available type: #{AmqpUtils::MessageFormatter.types.join(", ")}" unless @formatter
@@ -39,11 +31,8 @@ class SpyCommand < AmqpUtils::Command
     
     mq = MQ.new
     
-    exchange = MQ::Exchange.new(mq, options[:type], @exchange_name, :durable => options[:durable],
-      :auto_delete => options[:auto_delete])
-    
     queue = MQ::Queue.new(mq, spy_queue, :auto_delete => true)
-    queue.bind(exchange, :routing_key => @routing_key)
+    queue.bind(@exchange_name, :routing_key => @routing_key)
     
     queue.subscribe do |header, message|
       @formatter.generate(STDOUT, header, message)


### PR DESCRIPTION
Hey, I wrote a quick stand-alone spy script the other day, but I think it's got a better home in your amqp-utils gem :)

I don't know of a way to figure out the type, durability and auto-delete values of an exchange via the AMQP protocol, hence you have to manually supply those values to the command. Aside from that it's nice and easy to use.

Let me know if there's anything you don't like, or would like changed with the command :)

-jim
