### PR TITLE
amqp-peek - Set number of msgs to peek

### DIFF
--- a/bin/amqp-peek
+++ b/bin/amqp-peek
@@ -21,6 +21,7 @@ class PeekCommand < AmqpUtils::Command
       :short => :none, :default => 'pretty'
     options.opt :quiet, 'Suppresses non-message content output',
       :short => 'q', :default => false
+    options.opt :num, 'Number of msgs to peek',:short => 'n', :default => 1 
   end
 
   def validate
@@ -34,17 +35,19 @@ class PeekCommand < AmqpUtils::Command
     @queue = args[0]
 
     mq = MQ.new
-    mq.queue(@queue, :passive => true).pop(:ack => true) do |header, message|
-      if message
-        puts "(#{@queue})" unless options[:quiet]
-        deserialized_message = AmqpUtils::Serialization.deserialize(header.properties[:content_type], message)
-        @formatter.generate(STDOUT, header, deserialized_message)
-      else
-        puts "(#{@queue}) empty"
+    queue = mq.queue(@queue, :passive => true)
+    options[:num].times do
+      queue.pop(:ack => true) do |header, message|
+        if message
+          puts "(#{@queue})" unless options[:quiet]
+          deserialized_message = AmqpUtils::Serialization.deserialize(header.properties[:content_type], message)
+          @formatter.generate(STDOUT, header, deserialized_message)
+        else
+          puts "(#{@queue}) empty"
+        end
       end
-
-      AMQP.stop { EM.stop }
     end
+    AMQP.stop { EM.stop }
   end
 end
 


### PR DESCRIPTION
Hi, you might be interested to merge d4d0c57d5b95d116ad7abb8f0d84262b1a901f6f which enables the user of amqp-peek to set the number of msgs to peek from the queue.
