### PR TITLE
Minor changes in doc and bugfix for enqueue

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -20,8 +20,14 @@ other AMQP compliant queues. They depend on the amqp gem available at
 
 == INSTALL:
 
+To install from rubgems.org:
+
 * sudo gem install amqp-utils
 
+To build and install the local version:
+
+gem build amqp-utils.gemspec
+gem install amqp-utils-<VERSION>.gem
 == LICENSE:
 
 (The MIT License)

--- a/amqp-utils.gemspec
+++ b/amqp-utils.gemspec
@@ -55,7 +55,7 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<amqp>, ["~> 1.0"])
+      s.add_runtime_dependency(%q<amqp>, ["~> 0.7.1"])
       s.add_runtime_dependency(%q<trollop>, ["~> 1.16"])
       s.add_runtime_dependency(%q<facets>, ["~> 2.9"])
       s.add_runtime_dependency(%q<clio>, ["~> 0.3"])
@@ -63,7 +63,7 @@ Gem::Specification.new do |s|
       s.add_runtime_dependency(%q<heredoc_unindent>, ["~> 1.1"])
       s.add_runtime_dependency(%q<msgpack>, ["~> 0.5"])
     else
-      s.add_dependency(%q<amqp>, ["~> 1.0"])
+      s.add_runtime_dependency(%q<amqp>, ["~> 0.7.1"])
       s.add_dependency(%q<trollop>, ["~> 1.16"])
       s.add_dependency(%q<facets>, ["~> 2.9"])
       s.add_dependency(%q<clio>, ["~> 0.3"])
@@ -72,7 +72,7 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<msgpack>, ["~> 0.5"])
     end
   else
-    s.add_dependency(%q<amqp>, ["~> 1.0"])
+    s.add_runtime_dependency(%q<amqp>, ["~> 0.7.1"])
     s.add_dependency(%q<trollop>, ["~> 1.16"])
     s.add_dependency(%q<facets>, ["~> 2.9"])
     s.add_dependency(%q<clio>, ["~> 0.3"])

--- a/amqp-utils.gemspec
+++ b/amqp-utils.gemspec
@@ -55,30 +55,30 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<amqp>, ["~> 0.7.1"])
-      s.add_runtime_dependency(%q<trollop>, ["~> 1.16.2"])
+      s.add_runtime_dependency(%q<amqp>, ["~> 1.0"])
+      s.add_runtime_dependency(%q<trollop>, ["~> 1.16"])
       s.add_runtime_dependency(%q<facets>, ["~> 2.9"])
-      s.add_runtime_dependency(%q<clio>, ["~> 0.3.0"])
+      s.add_runtime_dependency(%q<clio>, ["~> 0.3"])
       s.add_runtime_dependency(%q<json>, ["~> 1.5"])
-      s.add_runtime_dependency(%q<heredoc_unindent>, ["~> 1.1.2"])
-      s.add_runtime_dependency(%q<msgpack>, ["~> 0.4.5"])
+      s.add_runtime_dependency(%q<heredoc_unindent>, ["~> 1.1"])
+      s.add_runtime_dependency(%q<msgpack>, ["~> 0.5"])
     else
-      s.add_dependency(%q<amqp>, ["~> 0.7.1"])
-      s.add_dependency(%q<trollop>, ["~> 1.16.2"])
+      s.add_dependency(%q<amqp>, ["~> 1.0"])
+      s.add_dependency(%q<trollop>, ["~> 1.16"])
       s.add_dependency(%q<facets>, ["~> 2.9"])
-      s.add_dependency(%q<clio>, ["~> 0.3.0"])
+      s.add_dependency(%q<clio>, ["~> 0.3"])
       s.add_dependency(%q<json>, ["~> 1.5"])
-      s.add_dependency(%q<heredoc_unindent>, ["~> 1.1.2"])
-      s.add_dependency(%q<msgpack>, ["~> 0.4.5"])
+      s.add_dependency(%q<heredoc_unindent>, ["~> 1.1"])
+      s.add_dependency(%q<msgpack>, ["~> 0.5"])
     end
   else
-    s.add_dependency(%q<amqp>, ["~> 0.7.1"])
-    s.add_dependency(%q<trollop>, ["~> 1.16.2"])
+    s.add_dependency(%q<amqp>, ["~> 1.0"])
+    s.add_dependency(%q<trollop>, ["~> 1.16"])
     s.add_dependency(%q<facets>, ["~> 2.9"])
-    s.add_dependency(%q<clio>, ["~> 0.3.0"])
+    s.add_dependency(%q<clio>, ["~> 0.3"])
     s.add_dependency(%q<json>, ["~> 1.5"])
-    s.add_dependency(%q<heredoc_unindent>, ["~> 1.1.2"])
-    s.add_dependency(%q<msgpack>, ["~> 0.4.5"])
+    s.add_dependency(%q<heredoc_unindent>, ["~> 1.1"])
+    s.add_dependency(%q<msgpack>, ["~> 0.5"])
   end
 end
 

--- a/amqp-utils.gemspec
+++ b/amqp-utils.gemspec
@@ -5,7 +5,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{amqp-utils}
-  s.version = "0.5.1"
+  s.version = "0.5.2"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Doug Barth"]

--- a/bin/amqp-enqueue
+++ b/bin/amqp-enqueue
@@ -20,6 +20,7 @@ class EnqueueCommand < AmqpUtils::Command
     BANNER
     options.opt :content_type, 'Sets the content_type header and chooses an appropriate serializer', :type => :string, :short => :none
     options.opt :persistent, 'Mark messages as persistent.', :short => :none
+    options.opt :notdurable, 'Specify channel as durable.', :short => :none
     options.opt :priority, 'The priority of this message', :type => :int, :short => :none, :default => 1
     options.opt :count, 'Number of times the message should be published. If multiple messages are provided, only the first message is published multiple times.', :type => :int, :default => 1
     options.opt :header, 'A key-value pair to be set in "headers" field of the AMQP header', :short => :none, :type => :string, :multi => true
@@ -63,7 +64,7 @@ class EnqueueCommand < AmqpUtils::Command
 
           serialized_message = AmqpUtils::Serialization.serialize(options.content_type, message)
 
-          @mq.queue(queue, :durable => true, :auto_delete => false).
+          @mq.queue(queue, :durable => !options.notdurable, :auto_delete => false).
             publish(serialized_message, publish_options)
 
           @progress.inc if @progress
@@ -99,7 +100,7 @@ class EnqueueCommand < AmqpUtils::Command
 
           serialized_message = AmqpUtils::Serialization.serialize(options.content_type, message['message'])
 
-          @mq.queue(queue, :durable => true, :auto_delete => false).
+          @mq.queue(queue, :durable => !options.notdurable, :auto_delete => false).
             publish(serialized_message, publish_options)
 
           publisher.notify(queue, message_io, formatter, options)

--- a/bin/amqp-enqueue
+++ b/bin/amqp-enqueue
@@ -40,7 +40,7 @@ class EnqueueCommand < AmqpUtils::Command
   end
 
   def execute
-    @queue = args
+    @queue = args[0]
     if options[:message]
       @message_io = StringIO.new(options[:message])
     else


### PR DESCRIPTION
I'm new to Ruby and to amqp so feel free to ignore/chastize as necessary

However, on my version of ruby (ruby 2.1.2p95 (2014-05-08 revision 45877) [x86_64-darwin13.0]) on my Mac, I had a problem with the queue name being mangled by amqp-enqueue.

It was a simple enough fix, so here you go ...

I also took the liberty of adding some details for building the gem from source for newbies such as myself, and to make it work for me I bumped the version number, but you can ignore that :-)
